### PR TITLE
Configurable APIs and Regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const defaultConfig = {
   core: {
     jar: 'minecraft_server.jar',
     args: ['-Xmx2G'],
-    pipeIO: true,
+    pipeIO: false,
     spawnOpts: {
       stdio: ['pipe', 'pipe', 'inherit'],
     },
@@ -16,21 +16,22 @@ const defaultConfig = {
       host: 'localhost',
       port: '25575',
       password: '0000',
-      buffer: 50,
+      buffer: 25,
     },
-    api: 'vanilla',
+    api: 'spigot',
     regex: {
       vanilla: {
         rcon_listening: /\[RCON Listener #1\/INFO\]: RCON running/i
       },
       spigot: {
-        rcon_listening: /\ INFO]: RCON running on/i
+        rcon_listening: /\ INFO]: RCON running on/i,
+        server_stopped: /\ INFO]: Stopping server/i
       },
       bukkit: {
         rcon_listening: /\ INFO]: RCON running on/i
       }
     }
-  },
+  }
 };
 
 class ScriptServer extends EventsEmitter {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
+const EventsEmitter = require( 'events' );
+const { spawn } = require( 'child_process' );
+const defaultsDeep = require( 'lodash.defaultsdeep' );
 
-const EventsEmitter = require('events');
-const { spawn } = require('child_process');
-const defaultsDeep = require('lodash.defaultsdeep');
-const Rcon = require('./Rcon');
+const Rcon = require( './rcon' );
 
 const defaultConfig = {
   core: {
@@ -34,68 +34,178 @@ const defaultConfig = {
   }
 };
 
-class ScriptServer extends EventsEmitter {
-  constructor(config = {}) {
+class Minecraft extends EventsEmitter {
+
+  constructor( config = {} ) {
+
     super();
-    this.config = defaultsDeep({}, config, defaultConfig);
+    this.config = defaultsDeep( {}, config, defaultConfig );
     this.api = this.config.core.api;
     this.modules = [];
 
-    // RCON
-    this.rcon = new Rcon(this.config.core.rcon);
-    this.on('console', (l) => {
-      if (l.match(this.config.core.regex[this.api].rcon_listening)) this.rcon.connect();
-    });
+    this.hasStarted = false;
+    this.hasRunning = false;
+    this.hasRestart = false;
+    this.hasStopped = true;
 
-    process.on('exit', () => this.stop());
-    process.on('close', () => this.stop());
+    // RCON
+    this.rcon = new Rcon( this.config.core.rcon );
+    this.on( 'console', ( l ) => {
+      if( l.match(this.config.core.regex[this.api].rcon_listening ) ) {
+
+        // Connect to RCON
+        this.rcon.connect();
+
+        if( this.hasRunning == false ) {
+
+          // Mark server as running
+          this.hasRunning = true;
+
+          // Emit that the server is running
+          this.emit( 'status', {
+            event: 'started',
+            message: 'Minecraft server has now started up and is running.'
+          } );
+
+        }
+
+      }
+    } );
+
+    process.on( 'exit', () => this.stop() );
+    process.on( 'close', () => this.stop() );
+
   }
 
   start() {
-    if (this.spawn) throw new Error('Server already started');
 
-    const args = this.config.core.args.concat('-jar', this.config.core.jar, 'nogui');
-    this.spawn = spawn('java', args, this.config.core.spawnOpts);
+    if( this.spawn ) throw new Error( 'Server already started' );
 
-    if (this.config.core.pipeIO) {
-      this.spawn.stdout.pipe(process.stdout);
-      process.stdin.pipe(this.spawn.stdin);
+    this.hasStopped = false;
+
+    const args = this.config.core.args.concat( '-jar', this.config.core.jar, 'nogui' );
+    this.spawn = spawn( 'java', args, this.config.core.spawnOpts );
+
+    if( this.config.core.pipeIO ) {
+      this.spawn.stdout.pipe( process.stdout );
+      process.stdin.pipe( this.spawn.stdin );
     }
 
-    this.spawn.stdout.on('data', (d) => {
-      // Emit console
-      d.toString().split('\n').forEach((l) => {
-        if (l) this.emit('console', l);
-      });
-    });
+    this.spawn.stdout.on( 'data', ( d ) => {
+      d.toString().split( '\n' ).forEach(( l ) => {
+        if( l ) {
+
+          // Check if server just started and emit starting status
+          if( this.hasStarted == false && this.hasStopped == false ) {
+
+            this.emit( 'status', {
+              event: 'starting',
+              message: 'Minecraft server is now starting up.'
+            } );
+
+            this.hasStarted = true;
+          }
+
+          // Emit to console
+          this.emit( 'console', l );
+
+        }
+      } );
+    } );
 
     return this;
+
   }
 
   stop() {
-    if (this.spawn) {
+
+    if( this.spawn ) {
+
       this.spawn.kill();
       this.spawn = null;
+      this.hasStopped = true;
+
+    }
+
+    this.emit( 'status', {
+      event: 'stopped',
+      message: 'Minecraft server has now been completely stopped.'
+    } );
+
+    this.hasStarted = false;
+    this.hasRunning = false;
+
+    if( this.hasRestart == true ) {
+
+      this.hasRestart = false;
+
+      return this.start();
+
     }
 
     return this;
+
   }
 
-  use(module) {
-    if (typeof module !== 'function') throw new Error('A module must be a function');
+  consoleStop() {
 
-    if (this.modules.filter(m => m === module).length === 0) {
-      this.modules.push(module);
-      module.call(this);
+    var variable = this;
+
+    variable.hasRestart = false;
+
+    variable.emit( 'status', {
+      event: 'stopping',
+      message: 'Minecraft server will shut down in 10 seconds.'
+    } );
+
+    variable.util.tellRaw( `Mineland serveren vil slå seg av om 10 sekunder.`, '@e', { color: 'red' } );
+
+    setTimeout( function() {
+      variable.stop();
+    }, 10000 );
+
+  }
+
+  consoleRestart() {
+
+    var variable = this;
+
+    variable.hasRestart = true;
+
+    variable.emit( 'status', {
+      event: 'restart',
+      message: 'Minecraft server will restart in 10 seconds.'
+    } );
+
+    variable.util.tellRaw( `Mineland serveren vil starte på nytt om 10 sekunder.`, '@e', { color: 'red' } );
+
+    setTimeout( function() {
+      variable.stop();
+    }, 10000 );
+
+  }
+
+  use( module ) {
+
+    if( typeof module !== 'function' ) throw new Error( '[Minecraft] A module must be a function.' );
+
+    if( this.modules.filter( m => m === module ).length === 0 ) {
+
+      this.modules.push( module );
+      module.call( this );
+
     }
 
     return this;
+
   }
 
-  send(command) {
-    return new Promise((resolve) => {
-      this.rcon.exec(command, result => resolve(result));
-    });
+  send( command ) {
+
+    return new Promise( ( resolve ) => {
+      this.rcon.exec( command, result => resolve( result ) );
+    } );
+
   }
 
   sendRaw( command ) {
@@ -105,6 +215,14 @@ class ScriptServer extends EventsEmitter {
     } );
 
   }
+
+  isRunning() {
+
+    if( this.hasRunning ) return true;
+    return false;
+
+  }
+
 }
 
-module.exports = ScriptServer;
+module.exports = Minecraft;

--- a/index.js
+++ b/index.js
@@ -97,6 +97,14 @@ class ScriptServer extends EventsEmitter {
       this.rcon.exec(command, result => resolve(result));
     });
   }
+
+  sendRaw( command ) {
+
+    return new Promise( ( resolve ) => {
+      this.spawn.stdin.write( `${command}\n` );
+    } );
+
+  }
 }
 
 module.exports = ScriptServer;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,18 @@ const defaultConfig = {
       password: '0000',
       buffer: 50,
     },
+    api: 'vanilla',
+    regex: {
+      vanilla: {
+        rcon_listening: /\[RCON Listener #1\/INFO\]: RCON running/i
+      },
+      spigot: {
+        rcon_listening: /\ INFO]: RCON running on/i
+      },
+      bukkit: {
+        rcon_listening: /\ INFO]: RCON running on/i
+      }
+    }
   },
 };
 
@@ -25,12 +37,13 @@ class ScriptServer extends EventsEmitter {
   constructor(config = {}) {
     super();
     this.config = defaultsDeep({}, config, defaultConfig);
+    this.api = this.config.core.api;
     this.modules = [];
 
     // RCON
     this.rcon = new Rcon(this.config.core.rcon);
     this.on('console', (l) => {
-      if (l.match(/\[RCON Listener #1\/INFO\]: RCON running/i)) this.rcon.connect();
+      if (l.match(this.config.core.regex[this.api].rcon_listening)) this.rcon.connect();
     });
 
     process.on('exit', () => this.stop());

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/garrettjoecox/scriptserver#readme",
   "dependencies": {
     "lodash.defaultsdeep": "^4.6.0",
-    "simple-rcon": "^0.3.1"
+    "simple-rcon": "github:garrettjoecox/simple-rcon#c2b0fd3"
   },
   "devDependencies": {
     "eslint": "^4.9.0",


### PR DESCRIPTION
A suggestion on how to implement multiple API's, this methods allows both user configuration, can add any API and or change any regex using config, as well as implementing pre-existing known regex patterns directly into the code.

New config

```
core: {
    api: 'vanilla',
    regex: {
      vanilla: {
        rcon_listening: /\[RCON Listener #1\/INFO\]: RCON running/i
      },
      spigot: {
        rcon_listening: /\ INFO]: RCON running on/i
      },
      bukkit: {
        rcon_listening: /\ INFO]: RCON running on/i
      }
    }
}
```

Where the `api` parameter will be the most used and common one.

Any thoughts?