### PR TITLE
Fixed server.stop() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,10 +70,7 @@ class ScriptServer extends EventsEmitter {
 
   stop() {
     if (this.spawn) {
-      this.rcon.disconnect();
-
-      this.spawn.kill();
-      this.spawn = null;
+      this.rcon.exec('stop', result => {this.rcon.disconnect(); return result});
     }
 
     return this;

--- a/index.js
+++ b/index.js
@@ -70,7 +70,10 @@ class ScriptServer extends EventsEmitter {
 
   stop() {
     if (this.spawn) {
-      this.rcon.exec('stop', result => {this.rcon.disconnect(); return result});
+      this.rcon.exec('stop', result => {
+        this.rcon.disconnect();
+        this.spawn = null;
+        return result});
     }
 
     return this;


### PR DESCRIPTION
Program would crash before fix with the following error:
```
events.js:292
      throw er; // Unhandled 'error' event
```
Used rcon to send a stop command, then disconnects from rcon to allow the server to shutdown to get around [a Minecraft bug](https://bugs.mojang.com/browse/MC-154617)